### PR TITLE
Closes #16: Expose original file name for tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -28,8 +28,9 @@ The Docker container comes with some popular commands preinstalled which can be 
 #### Placeholder Variables
 - `{{.result_folder}}`: Where the processed file must be placed
 - `{{.folder}}`: Directory the original file is in
-- `{{.name}}`: Original file name without extension
+- `{{.name}}`: Generated temporary file name without extension
 - `{{.extension}}`: Original file extension
+- `{{.original_name}}`: Original file name without extension encoded in base64
 
 ## Process Overview
 When a file is uploaded, IUO:

--- a/tasks.go
+++ b/tasks.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -135,6 +136,7 @@ func (tp *TaskProcessor) Run() error {
 	extension := path.Ext(basename)
 	values := map[string]string{
 		"result_folder": tp.tempWorkDir,
+		"original_name": base64.StdEncoding.EncodeToString([]byte(tp.OriginalFilename)),
 		"folder":        path.Dir(tp.tempOriginalFilePath),
 		"name":          strings.TrimSuffix(basename, extension),
 		"extension":     strings.TrimPrefix(extension, "."),


### PR DESCRIPTION
This follows the discussion of #16 
I made sure the `original_name` variable is encoded in base64 to avoid parsing issues.
Scripts can easily decode and parse as needed.

I only tested this locally as there were no tests available yet.