### PR TITLE
fix: streaming sync timeout and download conversion path matching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/joojoooo/immich-upload-optimizer:latest AS runtime
+RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM golang:1.25-alpine AS builder
+ARG VERSION=patched
+RUN apk add --no-cache git
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags "-X main.version=${VERSION}" -o /immich-upload-optimizer .
+
+FROM runtime
+COPY --from=builder /immich-upload-optimizer /usr/local/bin/immich-upload-optimizer
+ENTRYPOINT ["immich-upload-optimizer"]

--- a/helpers.go
+++ b/helpers.go
@@ -52,7 +52,7 @@ func isAssetView(r *http.Request) bool {
 
 func isOriginalDownloadPath(r *http.Request) (bool, []string) {
 	re := regexp.MustCompile(`^/api/assets/([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})/original$`)
-	matches := re.FindStringSubmatch(r.URL.String())
+	matches := re.FindStringSubmatch(r.URL.Path)
 	return r.Method == "GET" && len(matches) == 2, matches
 }
 

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ func main() {
 	}
 	// Proxy
 	proxy = httputil.NewSingleHostReverseProxy(remote)
+        proxy.FlushInterval = -1
 	if DevMITMproxy {
 		proxy.Transport = http.DefaultTransport
 		proxy.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyUrl)
@@ -147,6 +148,10 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		logger.Error(err, "")
 		return
 	default:
+		if r.URL.Path == "/api/sync/stream" {
+			// Stream endpoint uses long-lived responses incompatible with checksum replacement
+			break
+		}
 		if replacer := getChecksumReplacer(w, r, logger); replacer != nil {
 			logger.SetErrPrefix(fmt.Sprintf("replacer %d", replacer.typeId))
 			if err = replacer.Replace(); err == nil {


### PR DESCRIPTION
- Skip checksum replacer for /api/sync/stream to prevent buffering of long-lived streaming responses that cause mobile client timeouts
- Set proxy.FlushInterval = -1 for proper streaming response flushing
- Fix isOriginalDownloadPath matching r.URL.String() instead of r.URL.Path, which failed when query parameters were present
- Add local build Dockerfile