### PR TITLE
Implement duplicate rejection via api/assets/bulk-upload-check endpoint

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
@@ -30,9 +31,11 @@ func SHA1(file io.ReadSeeker) (string, error) {
 
 var mapLock sync.RWMutex
 var fakeToOriginalChecksum map[string]string
+var originalToFakeChecksum map[string]string
 
 func initChecksums() {
 	fakeToOriginalChecksum = make(map[string]string)
+	originalToFakeChecksum = make(map[string]string)
 	file, err := os.OpenFile(checksumsFile, os.O_CREATE|os.O_RDONLY, 0644)
 	if err != nil {
 		return
@@ -42,6 +45,7 @@ func initChecksums() {
 	for scanner.Scan() {
 		kv := strings.Split(scanner.Text(), ",")
 		fakeToOriginalChecksum[kv[0]] = kv[1]
+		originalToFakeChecksum[kv[1]] = kv[0]
 	}
 	if err := scanner.Err(); err != nil {
 		fmt.Println("Error reading csv:", err)
@@ -52,9 +56,72 @@ func addChecksums(fake, original string) {
 	go func() {
 		mapLock.Lock()
 		fakeToOriginalChecksum[fake] = original
+		originalToFakeChecksum[original] = fake
 		mapLock.Unlock()
 		_ = appendToCSV(fake, original)
 	}()
+}
+
+func checkBulkUpload(checksum string, r *http.Request) (exists bool, assetId string, err error) {
+	type checkItem struct {
+		ID       string `json:"id"`
+		Checksum string `json:"checksum"`
+	}
+	type checkRequest struct {
+		Assets []checkItem `json:"assets"`
+	}
+
+	reqBody, err := json.Marshal(checkRequest{
+		Assets: []checkItem{{ID: "check", Checksum: checksum}},
+	})
+	if err != nil {
+		return false, "", err
+	}
+
+	req, err := http.NewRequest("POST", upstreamURL+"/api/assets/bulk-upload-check", bytes.NewReader(reqBody))
+	if err != nil {
+		return false, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for _, key := range []string{"Authorization", "Cookie", "x-api-key"} {
+		if v := r.Header.Get(key); v != "" {
+			req.Header.Set(key, v)
+		}
+	}
+
+	resp, err := getHTTPclient().Do(req)
+	if err != nil {
+		return false, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", err
+	}
+
+	var result struct {
+		Results []struct {
+			Action  string `json:"action"`
+			AssetId string `json:"assetId"`
+		} `json:"results"`
+	}
+	if err = json.Unmarshal(body, &result); err != nil {
+		return false, "", err
+	}
+
+	if len(result.Results) > 0 && result.Results[0].Action == "reject" {
+		return true, result.Results[0].AssetId, nil
+	}
+	return false, "", nil
+}
+
+// reverseLookupChecksum finds the fake checksum for a given original checksum in O(1).
+func reverseLookupChecksum(original string) (string, bool) {
+	mapLock.RLock()
+	defer mapLock.RUnlock()
+	fake, found := originalToFakeChecksum[original]
+	return fake, found
 }
 
 func appendToCSV(key, value string) error {

--- a/jobs.go
+++ b/jobs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -33,8 +34,37 @@ func newJob(r *http.Request, w http.ResponseWriter, logger *customLogger) error 
 	jobs.Store(jobKey, jobID)
 	defer jobs.Delete(jobKey)
 
+	// Step 1: Compute SHA1 of original file and check with Immich BEFORE any processing
+	originalChecksum, sha1Err := SHA1(formFile)
+	if sha1Err != nil {
+		jobLogger.Printf("sha1 for bulk upload check failed: %s, proceeding", sha1Err.Error())
+	} else {
+		checksumToCheck := originalChecksum
+		if fakeChecksum, found := reverseLookupChecksum(originalChecksum); found {
+			checksumToCheck = fakeChecksum
+		}
+		alreadyExists, assetId, checkErr := checkBulkUpload(checksumToCheck, r)
+		if checkErr != nil {
+			jobLogger.Printf("bulk upload check failed: %s, proceeding", checkErr.Error())
+		} else if alreadyExists {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":        assetId,
+				"duplicate": true,
+				"status":    "duplicate",
+			})
+			jobLogger.Printf("skipped (already in Immich): \"%s\"", formFileHeader.Filename)
+			return nil
+		}
+	}
+	// Reset file position after SHA1 computation
+	if _, err = formFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("unable to seek beginning of file: %w", err)
+	}
+
+	// Step 2: Process file if a matching task exists
 	var originalHash string
-	var newHash string
 	uploadFile := formFile
 	uploadFilename := formFileHeader.Filename
 	uploadOriginal := true
@@ -62,7 +92,8 @@ func newJob(r *http.Request, w http.ResponseWriter, logger *customLogger) error 
 			_ = taskProcessor.CleanOriginalFile() // Save RAM before upload (tmpfs)
 		}
 	}
-	// Upload the original file or processed one if a task was found
+
+	// Step 3: Upload the original file or processed one
 	err = uploadUpstream(w, r, uploadFile, uploadFilename)
 	if err != nil {
 		jobLogger.Printf("upload upstream error: %s", err.Error())
@@ -71,10 +102,11 @@ func newJob(r *http.Request, w http.ResponseWriter, logger *customLogger) error 
 	if uploadOriginal {
 		jobLogger.Printf("uploaded original: \"%s\" (%s)", formFileHeader.Filename, humanReadableSize(formFileHeader.Size))
 	} else {
-		if newHash, err = SHA1(taskProcessor.ProcessedFile); err != nil {
+		if newHash, err := SHA1(taskProcessor.ProcessedFile); err != nil {
 			return fmt.Errorf("new sha1: %w", err)
+		} else {
+			addChecksums(newHash, originalHash)
 		}
-		addChecksums(newHash, originalHash)
 		jobLogger.Printf("uploaded: \"%s\" (%s) <- (%s) \"%s\"", taskProcessor.ProcessedFilename, humanReadableSize(taskProcessor.ProcessedSize), humanReadableSize(taskProcessor.OriginalSize), taskProcessor.OriginalFilename)
 	}
 


### PR DESCRIPTION
Fixes #36

I've tested it locally via browser:

1. upload image ✅ 
2. delete uploaded image and clear trash, upload image again ✅ 
3. upload same image (even different file name), is failling with dupliacte warning in the UI ✅ 

Use case 2 will lead to duplicate entries in the checksum.csv, but I think that isnt't too bad.

Server logs if there is a duplicate now:

```
immich-immich-upload-optimizer-1  | 2026/04/04 20:54:08 172.19.0.1: job 7: download original: "lima1.jpeg" (846.67 KB)
immich-immich-upload-optimizer-1  | 2026/04/04 20:54:08 172.19.0.1: job 7: skipped (already in Immich): "lima1.jpeg"
immich-immich-upload-optimizer-1  | 2026/04/04 20:54:08 172.19.0.1: request URL: /api/assets
```

---

Without the changes of this PR the server logs (database + immich server) would show errors AND IUO would waste resources to do the conversion for each image/video which does already exist. Additionally the checksum.csv would also get duplicate entries each time.

```
immich-upload-optimizer-1  | 2026/04/04 21:48:17 172.18.0.1: job 379: download original: "just-a-test.jpeg" (804.06 KB)
immich-upload-optimizer-1  | 2026/04/04 21:48:17 172.18.0.1: job 379: running task: lossy-images-to-avif: ./convert-images.sh 55 "/tempfs" "upload-1029129472" "jpeg" "/tempfs/processing-1573193618"
immich_postgres            | 2026-04-04 21:48:22.070 UTC [445627] ERROR:  duplicate key value violates unique constraint "UQ_assets_owner_checksum"
immich_postgres            | 2026-04-04 21:48:22.070 UTC [445627] DETAIL:  Key ("ownerId", checksum)=(295ba218-00ba-4bb9-95c9-b3417e765fb2, \x0fca24506b69ede90607515201b258bb3815f184) already exists.
immich_postgres            | 2026-04-04 21:48:22.070 UTC [445627] STATEMENT:  insert into "asset" ("ownerId", "libraryId", "checksum", "originalPath", "deviceAssetId", "deviceId", "fileCreatedAt", "fileModifiedAt", "localDateTime", "type", "isFavorite", "duration", "visibility", "originalFileName") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) returning *
immich_server              | Query failed : {
immich_server              |   durationMs: 4.4917402267456055,
immich_server              |   error: PostgresError: duplicate key value violates unique constraint "UQ_assets_owner_checksum"
immich_server              |       at ErrorResponse (/usr/src/app/server/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/cjs/src/connection.js:815:30)
immich_server              |       at handle (/usr/src/app/server/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/cjs/src/connection.js:489:6)
immich_server              |       at Socket.data (/usr/src/app/server/node_modules/.pnpm/postgres@3.4.8/node_modules/postgres/cjs/src/connection.js:324:9)
immich_server              |       at Socket.emit (node:events:508:28)
immich_server              |       at addChunk (node:internal/streams/readable:559:12)
immich_server              |       at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
immich_server              |       at Readable.push (node:internal/streams/readable:390:5)
immich_server              |       at TCP.onStreamRead (node:internal/stream_base_commons:189:23) {
immich_server              |     severity_local: 'ERROR',
immich_server              |     severity: 'ERROR',
immich_server              |     code: '23505',
immich_server              |     detail: 'Key ("ownerId", checksum)=(295ba218-00ba-4bb9-95c9-b3417e765fb2, \\x0fca24506b69ede90607515201b258bb3815f184) already exists.',
immich_server              |     schema_name: 'public',
immich_server              |     table_name: 'asset',
immich_server              |     constraint_name: 'UQ_assets_owner_checksum',
immich_server              |     file: 'nbtinsert.c',
immich_server              |     line: '663',
immich_server              |     routine: '_bt_check_unique'
immich_server              |   },
immich_server              |   sql: 'insert into "asset" ("ownerId", "libraryId", "checksum", "originalPath", "deviceAssetId", "deviceId", "fileCreatedAt", "fileModifiedAt", "localDateTime", "type", "isFavorite", "duration", "visibility", "originalFileName") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) returning *',
immich_server              |   params: [
immich_server              |     '295ba218-00ba-4bb9-95c9-b3417e765fb2',
immich_server              |     null,
immich_server              |     <Buffer 0f ca 24 50 6b 69 ed e9 06 07 51 52 01 b2 58 bb 38 15 f1 84>,
immich_server              |     '/usr/src/app/upload/upload/295ba218-00ba-4bb9-95c9-b3417e765fb2/c9/14/c914dd6b-5e8f-4765-bbc8-07bd44f48fa9.avif',
immich_server              |     'web-just-a-test.jpeg-1775033570463',
immich_server              |     'WEB',
immich_server              |     2026-04-01T08:52:50.463Z,
immich_server              |     2026-04-01T08:52:50.463Z,
immich_server              |     2026-04-01T08:52:50.463Z,
immich_server              |     'IMAGE',
immich_server              |     false,
immich_server              |     '0:00:00.000000',
immich_server              |     'timeline',
immich_server              |     'just-a-test.avif'
immich_server              |   ]
immich_server              | }
immich-upload-optimizer-1  | 2026/04/04 21:48:22 172.18.0.1: job 379: uploaded: "just-a-test.avif" (280.26 KB) <- (804.06 KB) "just-a-test.jpeg"
immich-upload-optimizer-1  | 2026/04/04 21:48:22 172.18.0.1: request URL: /api/assets
```

