### PR TITLE
Fix upload of Live photos via iOS

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -62,16 +62,20 @@ func newJob(r *http.Request, w http.ResponseWriter, logger *customLogger) error 
 	}
 	defer filePart.Close()
 
-	// Check for duplicate job using deviceAssetId before downloading the file
-	jobKey := ""
+	// Check for duplicate job using deviceAssetId+filename before downloading the file.
+	// Filename is included so Live Photo pairs (HEIC + MOV share the same deviceAssetId) aren't treated as duplicates of each other.
+	deviceAssetId := ""
 	if ids, ok := formValues["deviceAssetId"]; ok && len(ids) > 0 {
-		jobKey = ids[0]
+		deviceAssetId = ids[0]
 	}
-	if jobKey == "" {
-		// Never happens, but just in case
-		jobLogger.Print(magenta("no deviceAssetId found in form data, using filename as job key"))
-		jobKey = filePart.FileName()
+	if deviceAssetId == "" {
+		// deviceAssetId is already removed in this PR
+		// https://github.com/immich-app/immich/issues/27818
+		// and marked here to be removed: https://github.com/immich-app/immich/blob/b414b3d32b3952eb6f655d60b91240614be14acc/mobile/lib/services/foreground_upload.service.dart#L323
+		// ToDo: Need to use an alternative, because file name only is not "secure" enough
+		jobLogger.Print(magenta("no deviceAssetId found in form data, using filename only as job key"))
 	}
+	jobKey := deviceAssetId + "|" + filePart.FileName()
 
 	// The iOS app has a bug that randomly stops the 1st upload midway, causing an "unable to save uploaded file: unexpected EOF" error
 	// For this reason, we don't assume a job is a duplicate immediately and instead wait until the full asset is successfully downloaded by the existing job. Not waiting makes the app never upload the asset.


### PR DESCRIPTION
I've updated immich and immich (server+client) upload optimizer to the latest version.

Currently it is failing for Live photos, here is an example log:

2026/05/21 06:36:34 172.18.0.1: job 593: received: "IMG_9336.MOV" (deviceAssetId: 355A7C06-48E8-4161-BCCC-2CE5F3367DD7/L0/001)
2026/05/21 06:36:34 172.18.0.1: job 593: downloaded: "IMG_9336.MOV" (4.55 MB)
2026/05/21 06:37:47 172.18.0.1: job 594: received: "IMG_9336.HEIC" (deviceAssetId: 355A7C06-48E8-4161-BCCC-2CE5F3367DD7/L0/001)
2026/05/21 06:37:47 172.18.0.1: job err: job 594: job 593 is already processing this asset

I have used Claude Code with Opus 4.7 xhigh
and adjusted the comment regarding this:

https://github.com/immich-app/immich/blob/b414b3d32b3952eb6f655d60b91240614be14acc/mobile/lib/services/foreground_upload.service.dart#L323
```
// deviceAssetId/deviceId required by server v2.7.5 and below (drop in v4.0 per #27818).
```


https://github.com/immich-app/immich/issues/27818


> Breaking changes
> 
> Remove deviceId and deviceAssetId and the respective endpoint /assets/exists and /assets/device/:deviceId
