### PR TITLE
Immich v3 support, minimal changes only

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -71,17 +71,6 @@ func setChecksumPair(fake, original string) bool {
 	return true
 }
 
-func addChecksums(fake, original string) {
-	go func() {
-		mapLock.Lock()
-		changed := setChecksumPair(fake, original)
-		mapLock.Unlock()
-		if changed {
-			_ = appendToCSV(fake, original)
-		}
-	}()
-}
-
 func appendToCSV(key, value string) error {
 	file, err := os.OpenFile(checksumsFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {

--- a/checksum.go
+++ b/checksum.go
@@ -142,6 +142,17 @@ type assetMediaResponse struct {
 	Status string `json:"status"`
 }
 
+// Sync stream entries carrying an asset whose checksum must be replaced.
+// Immich v3 emits the V2 variants, older servers the V1 ones.
+var checksumRewriteStreamTypes = []string{
+	"AssetV1", "AssetV2",
+	"AlbumAssetCreateV1", "AlbumAssetCreateV2",
+	"AlbumAssetUpdateV1", "AlbumAssetUpdateV2",
+	"AlbumAssetBackfillV1", "AlbumAssetBackfillV2",
+	"PartnerAssetV1", "PartnerAssetV2",
+	"PartnerAssetBackfillV1", "PartnerAssetBackfillV2",
+}
+
 func replaceBulkUploadCheck(w http.ResponseWriter, r *http.Request, logger *customLogger) error {
 	logger.SetErrPrefix("bulk-upload-check")
 	var err error
@@ -264,7 +275,7 @@ func (replacer Replacer) Replace() (err error) {
 			}
 			for _, value := range streams {
 				if v, ok := value.(map[string]any); ok {
-					if t, ok := v["type"].(string); ok && !slices.Contains([]string{"AssetV1", "AlbumAssetCreateV1", "AlbumAssetUpdateV1", "AlbumAssetBackfillV1", "PartnerAssetV1", "PartnerAssetBackfillV1"}, t) {
+					if t, ok := v["type"].(string); ok && !slices.Contains(checksumRewriteStreamTypes, t) {
 						continue
 					}
 					if asset, ok := v["data"].(map[string]any); ok {

--- a/jobs.go
+++ b/jobs.go
@@ -218,21 +218,40 @@ func newJob(r *http.Request, w http.ResponseWriter, logger *customLogger) error 
 			_ = taskProcessor.CleanOriginalFile() // Save RAM before upload (tmpfs)
 		}
 	}
+	var newHash string
+	var checksumAdded bool
+	if !uploadOriginal {
+		// Register the mapping before uploading: Immich emits the upload-ready
+		// websocket event as soon as it accepts the asset, so the rewrite in
+		// handleWebSocketConn needs the pair to be in the map already.
+		if newHash, err = SHA1(uploadFile); err != nil {
+			return fmt.Errorf("job %d: new sha1: %w", jobID, err)
+		}
+		mapLock.Lock()
+		checksumAdded = setChecksumPair(newHash, originalHash)
+		mapLock.Unlock()
+	}
 	// Upload the original file or processed one if a task was found
 	err = uploadUpstream(w, r, uploadFile, uploadFilename, formValues)
 	if err != nil {
+		if checksumAdded {
+			// Drop the mapping again, otherwise a retry of the same file would
+			// see it as already known and never write it to the CSV.
+			mapLock.Lock()
+			delete(fakeToOriginalChecksum, newHash)
+			delete(originalToFakeChecksum, originalHash)
+			mapLock.Unlock()
+		}
 		http.Error(w, "failed to process file, view IUO logs for more info", http.StatusConflict)
 		return fmt.Errorf("job %d: upload upstream: %w", jobID, err)
 	}
 	if uploadOriginal {
 		jobLogger.Print(greenBold("uploaded original:") + " \"" + white(fileName) + "\" " + greenBold("(%s)", humanReadableSize(fileSize)))
 	} else {
-		if newHash, err := SHA1(taskProcessor.ProcessedFile); err == nil {
-			addChecksums(newHash, originalHash)
-			jobLogger.Print(greenBold("uploaded:") + " \"" + white(taskProcessor.ProcessedFilename) + "\" " + greenBold("(%s) <- (%s)", humanReadableSize(taskProcessor.ProcessedSize), humanReadableSize(taskProcessor.OriginalSize)) + " \"" + white(taskProcessor.OriginalFilename) + "\"")
-		} else {
-			return fmt.Errorf("job %d: new sha1: %w", jobID, err)
+		if checksumAdded {
+			_ = appendToCSV(newHash, originalHash)
 		}
+		jobLogger.Print(greenBold("uploaded:") + " \"" + white(taskProcessor.ProcessedFilename) + "\" " + greenBold("(%s) <- (%s)", humanReadableSize(taskProcessor.ProcessedSize), humanReadableSize(taskProcessor.OriginalSize)) + " \"" + white(taskProcessor.OriginalFilename) + "\"")
 	}
 
 	return nil

--- a/websocket.go
+++ b/websocket.go
@@ -68,7 +68,8 @@ func handleWebSocketConn(cliConn, srvConn *websocket.Conn, logger *customLogger)
 				switch wsMsg.getAction() {
 				case "on_upload_success":
 					asset = wsMsg.getUploadSuccessAsset()
-				case "AssetUploadReadyV1":
+				// Immich v3 emits the V2 events, older servers AssetUploadReadyV1
+				case "AssetUploadReadyV1", "AssetUploadReadyV2", "AssetEditReadyV2":
 					asset = wsMsg.getUploadReadyAsset()
 				}
 				if asset != nil {


### PR DESCRIPTION
Replaces #51, which was rightly closed as "too many unrelated changes". This is the same goal — support Immich v3 — reduced to only what v3 actually requires. Continues the discussion in #50.

**⚠️ Untested.** #51 was running in production, but this branch was rewritten from scratch against your minimal-change requirement, so the code here has not been exercised against a live v3 server yet. It builds clean (`go build`, `go vet`, `gofmt`). Please treat it as needing verification before merging — I'm happy to test it, or wait for others to.

## What changed

**38 insertions across 3 files.** #51 had 28,431 across 7.

### 1. v3 renamed the things that carry an asset checksum

IUO replaces the optimized file's checksum with the original one so clients keep recognising their own uploads. v3 renamed both places where that happens, so the proxy stopped matching and clients re-uploaded originals as duplicates (#50).

* **Sync stream** (`checksum.go`): added the `*V2` entity types alongside the existing `*V1` ones — `AssetV2`, `AlbumAssetCreateV2`, `AlbumAssetUpdateV2`, `AlbumAssetBackfillV2`, `PartnerAssetV2`, `PartnerAssetBackfillV2`.
* **WebSocket** (`websocket.go`): added `AssetUploadReadyV2` and `AssetEditReadyV2`.

Both name sets were checked against immich's source rather than guessed — `SyncEntityType` in `server/src/enum.ts` and `ClientEventMap` in `server/src/repositories/websocket.repository.ts`. `AssetEditReadyV2` carries a `SyncAssetV2`, which has a `checksum` field, so it needs the same rewrite. The V1 names are all kept, so older servers keep working.

The stream type list moved to a package-level variable. It was a literal inside the loop before, reallocated for every single stream entry.

### 2. The mapping was recorded too late

`addChecksums` ran *after* `uploadUpstream` returned, and inside a goroutine. But immich emits the upload-ready websocket event the moment it accepts an asset — so the event could reach the client before the mapping existed, and the rewrite silently did nothing. I believe this is the second half of the duplicates in #50.

The hash is now computed and the pair registered *before* the upload; the CSV write still only happens on success. `SHA1` and `uploadUpstream` both seek to the start themselves, so swapping the order of the two reads is safe.

On upload failure the pair is dropped again. Without that, a retry of the same file would find it already in the map, skip the CSV write, and the mapping would be lost on the next restart.

`addChecksums` has no callers left and is removed.

## What I deliberately left out

These were in #51. I'm listing them so it's clear they were dropped on purpose, not forgotten — happy to open any of them separately if you want them:

* **`immich-openapi-specs.json`** (28,032 lines) — reference material I used while working, does not belong in the repo.
* **Removing the `full-sync` / `delta-sync` handling.** Those endpoints are gone in v3, so the code is unreachable there — but it is not *broken*, and deleting it would break anyone still on an older server. Left untouched.
* **Removing `DevMITMproxy`.** That's your development tooling; I shouldn't have touched it. `main.go` and `helpers.go` are not modified at all in this PR.
* **A test suite** (`checksum_test.go`, ~290 lines). Any test in `package main` triggers `init()` under `go test`, which forces a `testing` import into the production binary to work around it. Not worth it inside a v3 fix. I have the tests if you'd like them as their own PR.
* **A `stagedChecksumPair` type with `Persist`/`Rollback`.** ~60 lines of structure for what the five inline lines above already do.
* Extra websocket logging and comment rewordings — noise.
